### PR TITLE
Website scaffold and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ python3 -m http.server --directory .
 
 e acesse `http://localhost:8000`.
 
+## Comandos úteis
+
+Para compilar o arquivo SCSS manualmente, utilize o [Dart Sass](https://sass-lang.com/install):
+
+```bash
+sass assets/styles/main.scss assets/styles/main.css --watch
+```
+
+Assim as alterações em `main.scss` serão refletidas automaticamente em `main.css`.
+
 ## Personalização
 
 - **Cores e tipografia:** edite as variáveis em `assets/styles/main.css` (ou o SCSS equivalente) para alterar a paleta de cores ou fontes.


### PR DESCRIPTION
## Summary
- initial scaffold of Audace marketing website
- add SCSS build instructions
- configure deployment to GitHub Pages

## Testing
- `curl -Is https://robertoah13.github.io/audace-website/ | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688b4d48ec288322a3684b83a4c391ea